### PR TITLE
Change entry point command from mysqld to mariadbd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY setup.sql /docker-entrypoint-initdb.d/
 # https://docs.docker.com/engine/reference/builder/#volume :
 #       Changing the volume from within the Dockerfile: If any build steps change the data within the volume after
 #       it has been declared, those changes will be discarded.
-RUN ["/usr/local/bin/docker-entrypoint.sh", "mysqld", "--datadir", "/initialized-db", "--aria-log-dir-path", "/initialized-db"]
+RUN ["/usr/local/bin/docker-entrypoint.sh", "mariadbd", "--datadir", "/initialized-db", "--aria-log-dir-path", "/initialized-db"]
 
 FROM mariadb:latest
 


### PR DESCRIPTION
The command to start MariaDB was changed to mariadbd in v10.5.2 [MDEV-21303](https://jira.mariadb.org/browse/MDEV-21303)